### PR TITLE
Revert 10x randomness update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "random_id" "random" {
     uuid = "${uuid()}"
   }
 
-  byte_length = 120
+  byte_length = 12
 }
 
 output "random" {


### PR DESCRIPTION
**These changes were overall a bad idea.**

Performance was the main problem, but there were also several others:

- Too many zeroes
- Not enough ones
- Insufficient justification for change request

Undoing for now. Sorry!